### PR TITLE
feat(script): support some outputs for ecs instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,9 @@ Full contributing [guidelines are covered here](.github/how_to_contribute.md).
 |------|-------------|
 | instance_ids | The ID list of the ECS instances |
 | instance_id | The ID of the first ECS instance |
+| instance_name | The name of the first ECS instance |
+| instance_status | The status of the first ECS instance |
+| instance_public_ip | The public IP of the first ECS instance |
+| instance_access_ipv4 | The fixed IPv4 address or the floating IP of the first ECS instance |
+| instance_access_ipv6 | The fixed IPv6 address of the first ECS instance |
+| instance_network | The network object of the first ECS instance |

--- a/examples/simple-ecs/README.md
+++ b/examples/simple-ecs/README.md
@@ -68,3 +68,16 @@ Note that this example will create an instance and spend a few money. Run `terra
 | system_disk_size | The size of the system volume, in GB | number | 60 |
 | data_disks_configuration | The configuration of data volumes of the ECS instance | <pre>list(object({<br>  type = string<br>  size = number<br>}))</pre> | <pre>[{<br>  type = "SAS"<br>  size = 60<br>}]</pre> |
 | admin_password | The login password of the administrator | string | null |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| instance_ids | The ID list of the ECS instances |
+| instance_id | The ID of the first ECS instance |
+| instance_name | The name of the first ECS instance |
+| instance_status | The status of the first ECS instance |
+| instance_public_ip | The public IP of the first ECS instance |
+| instance_access_ipv4 | The fixed IPv4 address or the floating IP of the first ECS instance |
+| instance_access_ipv6 | The fixed IPv6 address of the first ECS instance |
+| instance_network | The network object of the first ECS instance |

--- a/examples/simple-ecs/outputs.tf
+++ b/examples/simple-ecs/outputs.tf
@@ -1,0 +1,31 @@
+output "instance_ids" {
+    value = module.ecs_service.instance_ids
+}
+
+output "instance_id" {
+    value = module.ecs_service.instance_id
+}
+
+output "instance_name" {
+    value = module.ecs_service.instance_name
+}
+
+output "instance_status" {
+    value = module.ecs_service.instance_status
+}
+
+output "instance_public_ip" {
+    value = module.ecs_service.instance_public_ip
+}
+
+output "instance_access_ipv4" {
+    value = module.ecs_service.instance_public_ip
+}
+
+output "instance_access_ipv6" {
+    value = module.ecs_service.instance_public_ip
+}
+
+output "instance_network" {
+    value = module.ecs_service.instance_public_ip
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,8 +4,45 @@ output "instance_ids" {
   value = huaweicloud_compute_instance.this[*].id
 }
 
+// If you only create one instance, you can refer to the following parameters.
 output "instance_id" {
   description = "The ID of the first ECS instance"
 
   value = try(huaweicloud_compute_instance.this[0].id, "")
+}
+
+output "instance_name" {
+  description = "The name of the first ECS instance"
+
+  value = try(huaweicloud_compute_instance.this[0].name, "")
+}
+
+output "instance_status" {
+  description = "The status of the first ECS instance"
+
+  value = try(huaweicloud_compute_instance.this[0].status, "")
+}
+
+output "instance_public_ip" {
+  description = "The public IP of the first ECS instance"
+
+  value = try(huaweicloud_compute_instance.this[0].public_ip, "")
+}
+
+output "instance_access_ipv4" {
+  description = "The fixed IPv4 address or the floating IP of the first ECS instance"
+
+  value = try(huaweicloud_compute_instance.this[0].access_ip_v4, "")
+}
+
+output "instance_access_ipv6" {
+  description = "The fixed IPv6 address of the first ECS instance"
+
+  value = try(huaweicloud_compute_instance.this[0].access_ip_v6, "")
+}
+
+output "instance_network" {
+  description = "The network object of the first ECS instance"
+
+  value = try(huaweicloud_compute_instance.this[0].network, "")
 }


### PR DESCRIPTION
Support some output used to reference.
| Name | Description |
|------|-------------|
| instance_ids | The ID list of the ECS instances |
| instance_id | The ID of the first ECS instance |
| instance_name | The name of the first ECS instance |
| instance_status | The status of the first ECS instance |
| instance_public_ip | The public IP of the first ECS instance |
| instance_access_ipv4 | The fixed IPv4 address or the floating IP of the first ECS instance |
| instance_access_ipv6 | The fixed IPv6 address of the first ECS instance |
| instance_network | The network object of the first ECS instance |